### PR TITLE
Same as #1 (using trunk instead of master) with base branch updated via GitHub UI

### DIFF
--- a/trunk_branch_2.txt
+++ b/trunk_branch_2.txt
@@ -1,0 +1,1 @@
+trunk_branch_2


### PR DESCRIPTION
An example of what happens if the base branch is changed via the edit button.

Before the base change, commit 8af34e7d5d39218fe2a1e4f1b143f2951e1a4484, which was added to `trunk` after this PR was created, was showing up in this PR (Similar to https://github.com/adamu/merge-test/pull/1/commits/07d33490934967f1119ae0bf97bf8118fde1c4ca on #1). Now it's been removed by the base change.